### PR TITLE
Revert "removed RequestCurrentStats() func as steamworks sdk no longer suppor…"

### DIFF
--- a/Code/Include/Steamworks/SteamworksBus.h
+++ b/Code/Include/Steamworks/SteamworksBus.h
@@ -27,6 +27,8 @@ namespace Steamworks
 			virtual ~SteamUserStatsRequests() = default;
 			// Put your public methods here
             // steamuserstats Requests
+            // Achievements (currently the only thing supported because our game only uses achievements)
+            virtual bool SR_RequestCurrentStats() = 0;
             //virtual bool GetAchievement(const char *name, bool *achieved) = 0;
             virtual bool SR_SetAchievement(const char* name) = 0;
             //virtual bool ClearAchievement(const char *name) = 0;

--- a/Code/Source/Clients/SteamworksSystemComponent.cpp
+++ b/Code/Source/Clients/SteamworksSystemComponent.cpp
@@ -87,6 +87,7 @@ namespace Steamworks
             behaviorContext->EBus<SteamUserStatsRequestBus>("SteamUserStats Requests")
                 ->Attribute(AZ::Script::Attributes::Category, "Steamworks/Steam User Stats")
                 ->Attribute(AZ::Script::Attributes::Scope, AZ::Script::Attributes::ScopeFlags::Common)
+                ->Event("RequestCurrentStats", &SteamUserStatsRequestBus::Events::SR_RequestCurrentStats)
                 ->Event("SetAchievement", &SteamUserStatsRequestBus::Events::SR_SetAchievement)
                 ->Event("SteamInitialized", &SteamUserStatsRequestBus::Events::SR_SteamInitialized);
 
@@ -168,6 +169,7 @@ namespace Steamworks
             m_pSteamUser = SteamUser();
             m_pSteamUserStats = SteamUserStats();
             m_pSteamFriends = SteamFriends();
+            SteamworksSystemComponent::SR_RequestCurrentStats();
         }
 #ifdef _RELEASE
         // Checks for steam client and initializes steam API - only in release builds
@@ -191,6 +193,16 @@ namespace Steamworks
         if (steamAPIInitialized) {
 			SteamAPI_Shutdown();
 		}
+    }
+
+    bool SteamworksSystemComponent::SR_RequestCurrentStats() {
+        if (m_pSteamUserStats == NULL || m_pSteamUser == NULL) {
+            return false;
+        }
+        if (!m_pSteamUser->BLoggedOn()) {
+            return false;
+        }
+        return m_pSteamUserStats->RequestCurrentStats();
     }
 
     bool SteamworksSystemComponent::SR_SetAchievement(const char* name)  {

--- a/Code/Source/Clients/SteamworksSystemComponent.h
+++ b/Code/Source/Clients/SteamworksSystemComponent.h
@@ -71,6 +71,11 @@ namespace Steamworks
         ISteamUserStats* m_pSteamUserStats;
         ISteamFriends* m_pSteamFriends;
 
+        // SteamworksRequestBus::Handler interface implementation
+        
+        // SteamUserStatsRequestBus::Handler interface implementation
+
+        bool SR_RequestCurrentStats() override;
         //bool GetAchievement(const char* name, bool* achieved) override;
         bool SR_SetAchievement(const char* name) override;
         //bool ClearAchievement(const char* name) override;


### PR DESCRIPTION
Reverts Team-Plutinite/o3de-steam-gem#3
RequestCurrentStats is deprecated in the current version of the SDK, but the rest of the gem depends on it to function. So either needs to be rewritten to function without it or left with a disclaimer that this only supports up to SDK version 1.59